### PR TITLE
Missing ~ changes what this does

### DIFF
--- a/socialmedia-exception.txt
+++ b/socialmedia-exception.txt
@@ -5,4 +5,4 @@
 ! Description: No mercy for 3rd Party Frames except for common Social Media sites and Google.
 ! Homepage: https://github.com/thedoggybrad/Frame-Blocker-Filter
 !
-*$subdocument,third-party,domain=~facebook.com|~instagram.com|~meta.com|~twitter.com|~youtube.com|~tiktok.com|~pinterest.com|~reddit.com|~quora.com|~linkedin.com|~tumblr.com|~flickr.com|~vimeo.com|~wattpad.com|google.com
+*$subdocument,third-party,domain=~facebook.com|~instagram.com|~meta.com|~twitter.com|~youtube.com|~tiktok.com|~pinterest.com|~reddit.com|~quora.com|~linkedin.com|~tumblr.com|~flickr.com|~vimeo.com|~wattpad.com|~google.com


### PR DESCRIPTION
Without a `~` before `google.com`, it makes it so this filter _only_ applies to `google.com`, instead of excluding it.
Thanks